### PR TITLE
🐛 Fix EW hand display issue 

### DIFF
--- a/src/views/bridge/bridgeTerminalView.cpp
+++ b/src/views/bridge/bridgeTerminalView.cpp
@@ -7,11 +7,11 @@
 
 #include <range/v3/iterator/operations.hpp>
 #include <range/v3/view/cartesian_product.hpp>
-#include <range/v3/view/for_each.hpp>
-#include <range/v3/view/enumerate.hpp>
-#include <range/v3/view/zip.hpp>
-#include <range/v3/view/filter.hpp>
 #include <range/v3/view/chunk.hpp>
+#include <range/v3/view/enumerate.hpp>
+#include <range/v3/view/filter.hpp>
+#include <range/v3/view/for_each.hpp>
+#include <range/v3/view/zip.hpp>
 
 #include <iostream>
 #include <optional>
@@ -92,7 +92,7 @@ std::string BridgeTerminalView::getGamestateString(const BridgeGamestate& bg) {
 
   std::stringstream ss;
   ss << getContractAndTurnInfo(bg) << getNSHand(handStr["N"]) << "\n"
-     << getEWHand(handStr["E"], handStr["W"], bg) << "\n"
+     << getEWHand(std::move(handStr["E"]), std::move(handStr["W"]), bg) << "\n"
      << getNSHand(handStr["S"]);
 
   return ss.str();
@@ -121,16 +121,19 @@ std::string BridgeTerminalView::getNSHand(
   return ss.str();
 }
 
-std::string BridgeTerminalView::getEWHand(const std::vector<std::string>& eHand,
-                                          const std::vector<std::string>& wHand,
+std::string BridgeTerminalView::getEWHand(std::vector<std::string>&& eHand,
+                                          std::vector<std::string>&& wHand,
                                           const BridgeGamestate& bg) {
 
   std::vector<BridgeCard> currPlayedCards = bg.currentTrickRecord();
   std::vector<std::string> playedCards = getPlayedCards(bg);
 
+  const auto [eHandPadded, wHandPadded] = detail::padVectorsToBeSameLength(
+      std::move(eHand), std::move(wHand), std::string{});
+
   std::stringstream ss;
   for (auto [i, cards] :
-       ranges::views::enumerate(ranges::views::zip(eHand, wHand))) {
+       ranges::views::enumerate(ranges::views::zip(eHandPadded, wHandPadded))) {
     const auto& [eCards, wCards] = cards;
     auto playedCard =
         i < playedCards.size() ? playedCards[i] : std::string(12, ' ');

--- a/src/views/bridge/bridgeTerminalView.hpp
+++ b/src/views/bridge/bridgeTerminalView.hpp
@@ -8,6 +8,25 @@
 
 namespace Bridge {
 
+namespace detail {
+
+template <typename T>
+std::pair<std::vector<T>, std::vector<T>> padVectorsToBeSameLength(
+    std::vector<T>&& leftHand, std::vector<T>&& rightHand, const T& valueToPadWith) {
+  size_t lSize = leftHand.size();
+  size_t rSize = rightHand.size();
+
+  if (lSize > rSize) {
+    rightHand.resize(lSize, valueToPadWith);
+  }
+
+  if (lSize < rSize) {
+    leftHand.resize(rSize, valueToPadWith);
+  }
+  return std::pair{leftHand, rightHand};
+}
+}  // namespace Detail
+
 class BridgeTerminalView {
 
  public:
@@ -20,8 +39,8 @@ class BridgeTerminalView {
 
   static std::string getContractAndTurnInfo(const BridgeGamestate& gamestate);
 
-  static std::string getEWHand(const std::vector<std::string>& eHand,
-                               const std::vector<std::string>& wHand,
+  static std::string getEWHand(std::vector<std::string>&& eHand,
+                               std::vector<std::string>&& wHand,
                                const BridgeGamestate& bg);
 
   static std::vector<std::string> getCardsOfSuitString(


### PR DESCRIPTION
The issue came from ranges::views::zip giving an iterator with the size of the shortest container passed into it 

It was fixed by padding the East and west hand's vectors to be the same size with a generalised utility function

Fixes #12 